### PR TITLE
Fix semantics on annotation page and include UX JS

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -9,24 +9,25 @@ h1 {
     padding-bottom: 40px;
 }
 
+div.divide {
+  margin-top: 1.7em;
+}
+
+.button {
+    width: 100%;
+    text-align: center;
+}
+
 .button.button-primary {
     color: whitesmoke;
     background-color: cornflowerblue;
     border-color: cornflowerblue;
-    display: inline-block;
-    width: 150px;
     text-align: center;
 }
 
 .button.button-primary:hover {
     background-color: #4670ba;
     border-color: #4670ba;
-}
-
-.button {
-    display: inline-block;
-    width: 150px;
-    text-align: center;
 }
 
 input[type="radio"], input[type="checkbox"] {
@@ -44,8 +45,8 @@ input[type="checkbox"]:checked + label {
 }
 
 #submit {
-    border-color: forestgreen;
-    background-color: forestgreen;
+    border-color: limegreen;
+    background-color: limegreen;
 }
 
 #submit:hover {

--- a/static/js/annotate.js
+++ b/static/js/annotate.js
@@ -5,12 +5,12 @@
 function fineReveal() {
   var elem = document.querySelectorAll('#fine1, #fine2');
   Array.prototype.forEach.call(elem, function(e) {
-    e.style.display = 'inline-block';
+    e.style.display = 'block';
   });
 }
 
 function submitReveal() {
-  document.getElementById('submit').style.display = 'inline-block';
+  document.getElementById('submit').style.display = 'block';
 }
 
 function init() {

--- a/static/js/annotate.js
+++ b/static/js/annotate.js
@@ -1,0 +1,36 @@
+/* annotate.js
+ * Hide and reveal user interface elements to create a nice UX flow.
+ */
+
+function fineReveal() {
+  var elem = document.querySelectorAll('#fine1, #fine2');
+  Array.prototype.forEach.call(elem, function(e) {
+    e.style.display = 'inline-block';
+  });
+}
+
+function submitReveal() {
+  document.getElementById('submit').style.display = 'inline-block';
+}
+
+function init() {
+  var coarse = document.querySelectorAll('#coarse input');
+  var fine   = document.querySelectorAll('#fine1 input, #fine2 input');
+  var hidden = document.querySelectorAll('#fine1, #fine2, #submit');
+
+  Array.prototype.forEach.call(coarse, function(e) {
+    e.onchange = fineReveal;
+  });
+  Array.prototype.forEach.call(fine, function(e) {
+    e.onchange = submitReveal;
+  });
+  Array.prototype.forEach.call(hidden, function(e) {
+    e.style.display = 'none';
+  });
+}
+
+if (document.attachEvent? document.readyState === "complete": document.readyState !== "loading") {
+  init();
+} else {
+  document.addEventListener('DOMContentLoaded', init);
+}

--- a/templates/annotate.html
+++ b/templates/annotate.html
@@ -1,33 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-
-  <!-- Basic Page Needs
-  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <meta charset="utf-8">
-  <title>SENTIMENTATOR</title>
-  <meta name="description" content="">
-  <meta name="author" content="">
-
-  <!-- Mobile Specific Metas
-  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-
-  <!-- FONT
-  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
-
-  <!-- CSS
-  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-	<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/normalize.css') }}" />
-	<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/skeleton.css') }}" />
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/custom.css') }}" />
-
-
-  <!-- Favicon
-  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png') }}">
-
+<meta charset="utf-8">
+<title>Sentimentator</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/normalize.css') }}" />
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/skeleton.css') }}" />
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/custom.css') }}" />
+<link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png') }}">
 </head>
 <header>
 <form method="post" action="/annotate/{{ lang }}">

--- a/templates/annotate.html
+++ b/templates/annotate.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<meta charset="utf-8">
 <title>Sentimentator</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
@@ -10,63 +9,93 @@
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/custom.css') }}" />
 <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png') }}">
 </head>
-<header>
-<form method="post" action="/annotate/{{ lang }}">
-	<div class="container" style="text-align: center">
-		<div class="row">
-			<div style="margin-top: 15%; margin-bottom: 25%">
- 			    <h1>SENTIMENTATOR</h1>
-                <p>Select the emotions which you think best suit the sentence.</p>
-                <p>{{ sentence }}</p>
-                <div class="sentiment-selection">
-                    <input type="radio" name="sentiment" id="pos" value="pos">
-                    <label for="pos" class="button button-primary">POSITIVE</label>
-                    <input type="radio" name="sentiment" id="neut" value="neut">
-                    <label for="neut" class="button button-primary">NEUTRAL</label>
-                    <input type="radio" name="sentiment" id="neg" value="neg">
-                    <label for="neg" class="button button-primary">NEGATIVE</label>
-
-                </div><br>
-                <div class="eight columns offset-by-two">
-                    <input type="checkbox" name="fine-sentiment" id="ant" value="ant">
-                    <label for="ant" class="button">ANTICIPATION</label>
-
-                    <input type="checkbox" name="fine-sentiment" id="joy" value="joy">
-                    <label for="joy" class="button">JOY</label>
-
-                    <input type="checkbox" name="fine-sentiment" id="sur">
-                    <label for="sur" class="button">SURPRISE</label>
-
-                    <input type="checkbox" name="fine-sentiment" id="tru">
-                    <label for="tru" class="button">TRUST</label>
-
-                    <input type="checkbox" name="fine-sentiment" id="ang">
-                    <label for="ang" class="button">ANGER</label>
-
-                    <input type="checkbox" name="fine-sentiment" id="fea">
-                    <label for="fea" class="button">FEAR</label>
-
-                    <input type="checkbox" name="fine-sentiment" id="dis">
-                    <label for="dis" class="button">DISGUST</label>
-
-                    <input type="checkbox" name="fine-sentiment" id="sad">
-                    <label for="sad" class="button">SADNESS</label>
-                </div>
-                <div class="twelve columns">
-                    <input type="submit" id="submit" class="button button-primary" style="margin-top: 20px" value="SAVE">
-                </div>
-			    <figure>
-	   		    <img src="/static/images/Plutchik_Wheel.png">
-		        <figcaption>Plutchik's wheel of emotions.
-                <p>https://en.wikipedia.org/wiki/Contrasting_and_categorization_of_emotions</p></figcaption>
-			    </figure>
-                <a href="/logout" class="button" style="margin-top: 5%; margin-bottom: 25%">LOG OUT</a>
-			</div>
-	    </div>
-	</div>
-</form>
-</header>
 <body>
 
+<form method="post" action="/annotate/{{ lang }}">
+<div class="container">
+
+<div class="row">
+  <h1>Sentimentator</h1>
+</div>
+
+<div class="row">
+  <p class="info">Select the emotions which you think best suit the sentence.</p>
+  <p class="sentence">» This is a example lorem ipsum sentence. «</p>
+</div>
+
+<div id="coarse" class="row divide">
+  <div class="four columns">
+    <input type="radio" name="sentiment" id="pos" value="positive">
+    <label for="pos" class="button button-primary">positive</label>
+  </div>
+
+  <div class="four columns">
+  <input type="radio" name="sentiment" id="neut" value="neutral">
+  <label for="neut" class="button button-primary">neutral</label>
+  </div>
+
+  <div class="four columns">
+    <input type="radio" name="sentiment" id="neg" value="negative">
+    <label for="neg" class="button button-primary">negative</label>
+  </div>
+</div>
+
+<div id="fine-fst" class="row divide">
+  <div class="three columns">
+    <input type="checkbox" name="fine-sentiment" id="ant" value="ant">
+    <label for="ant" class="button">anticipation</label>
+  </div>
+
+  <div class="three columns">
+    <input type="checkbox" name="fine-sentiment" id="joy" value="joy">
+    <label for="joy" class="button">joy</label>
+  </div>
+
+  <div class="three columns">
+    <input type="checkbox" name="fine-sentiment" id="sur" value="sur">
+    <label for="sur" class="button">surprise</label>
+  </div>
+
+  <div class="three columns">
+    <input type="checkbox" name="fine-sentiment" id="tru" value="tru">
+    <label for="tru" class="button">trust</label>
+  </div>
+</div>
+
+<div id="fine-snd" class="row">
+  <div class="three columns">
+    <input type="checkbox" name="fine-sentiment" id="ang" value="ang">
+    <label for="ang" class="button">anger</label>
+  </div>
+
+  <div class="three columns">
+    <input type="checkbox" name="fine-sentiment" id="fea" value="fea">
+    <label for="fea" class="button">fear</label>
+  </div>
+
+  <div class="three columns">
+    <input type="checkbox" name="fine-sentiment" id="dis" value="dis">
+    <label for="dis" class="button">disgust</label>
+  </div>
+
+  <div class="three columns">
+    <input type="checkbox" name="fine-sentiment" id="sad" value="sad">
+    <label for="sad" class="button">sadness</label>
+  </div>
+</div>
+
+<div class="row divide">
+<input type="submit" id="submit" class="button button-primary" value="save">
+</div>
+
+<div class="row divide">
+<figure>
+<img src="/static/images/Plutchik_Wheel.png">
+<figcaption><a href="https://en.wikipedia.org/wiki/Contrasting_and_categorization_of_emotions">Plutchik's wheel of emotions.</a></figcaption>
+</figure>
+</div>
+
+</div> <!-- class=container -->
+</form>
 </body>
 </html>

--- a/templates/annotate.html
+++ b/templates/annotate.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/skeleton.css') }}" />
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/custom.css') }}" />
 <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png') }}">
+<script src="{{ url_for('static', filename='js/annotate.js') }}"></script>
 </head>
 <body>
 
@@ -40,7 +41,7 @@
   </div>
 </div>
 
-<div id="fine-fst" class="row divide">
+<div id="fine1" class="row divide">
   <div class="three columns">
     <input type="checkbox" name="fine-sentiment" id="ant" value="ant">
     <label for="ant" class="button">anticipation</label>
@@ -62,7 +63,7 @@
   </div>
 </div>
 
-<div id="fine-snd" class="row">
+<div id="fine2" class="row">
   <div class="three columns">
     <input type="checkbox" name="fine-sentiment" id="ang" value="ang">
     <label for="ang" class="button">anger</label>


### PR DESCRIPTION
This PR consists or two relevant parts. First semantics on the annotation page are corrected to be more sane. Changes include more streamlines header, better utilization of Skeleton (especially grid layout), and a sound body element.

Second part sprinkles some Javascript to hide and reveal UI elements to guide user through annotation process.

Additionally changes break visuals, which need to be fixed later, but that should be easier thanks to sane DOM.